### PR TITLE
Revert $theta -> @theta change

### DIFF
--- a/R/dmn.R
+++ b/R/dmn.R
@@ -65,7 +65,7 @@ mixturewt <-
 {
     fit <- object@fit$Estimate
     if (scale)
-        fit <- scale(fit, FALSE, mixturewt(object)@theta)
+        fit <- scale(fit, FALSE, mixturewt(object)$theta)
     fit
 }
 


### PR DESCRIPTION
This change causes the following error:

> heatmapdmn(count, fit[[1]], fit[[4]])
> Error in scale.default(fit, FALSE, mixturewt(object)@theta) : 
>   trying to get slot "theta" from an object (class "data.frame") that is not an S4 object 
